### PR TITLE
Change: use automatic gradient

### DIFF
--- a/examples/simple_state_to_state.jl
+++ b/examples/simple_state_to_state.jl
@@ -137,13 +137,11 @@ problem = ControlProblem(
     pulse_options=Dict(),
     iter_stop=500,
     J_T=QuantumControl.Functionals.J_T_sm,
-    gradient=QuantumControl.Functionals.grad_J_T_sm!,
     check_convergence=res -> begin
         ((res.J_T < 1e-3) && (res.converged = true) && (res.message = "J_T < 10⁻³"))
     end,
 );
 
-# Note that we have given an explicit function that calculates the gradient $\partial J_T/\partial \tau$
 
 # ## Simulate dynamics under the guess field
 
@@ -183,15 +181,13 @@ opt_result_LBFGSB, file = @optimize_or_load(
     datadir("TLS"),
     problem,
     method = :grape,
+    force = true,
     filename = "opt_result_LBFGSB.jld2",
     info_hook = chain_infohooks(
         GRAPELinesearchAnalysis.plot_linesearch(datadir("TLS", "Linesearch", "LBFGSB")),
         QuantumControl.GRAPE.print_table,
     )
 );
-#-
-#jl # do a single iteration, to ensure coverage
-#jl optimize(problem, method = :grape, iter_stop=1)
 #-
 #jl @test opt_result_LBFGSB.J_T < 1e-3
 #-
@@ -208,6 +204,13 @@ opt_result_LBFGSB
 fig = plot_control(opt_result_LBFGSB.optimized_controls[1], tlist)
 #jl display(fig)
 #-
+
+
+# ## Optimization via χ
+
+opt_result_LBFGSB_via_χ = optimize(problem; method=:grape, gradient_via=:chi);
+#-
+opt_result_LBFGSB_via_χ
 
 # ## Optimization with Optim.jl
 

--- a/src/backend_lbfgsb.jl
+++ b/src/backend_lbfgsb.jl
@@ -15,12 +15,12 @@ function run_optimizer(optimizer::LBFGSB.L_BFGS_B, wrk, fg!, info_hook, check_co
     m = 10
     factr = 1e7
     pgtol = 1e-5
-    iprint = -1 # TODO
+    iprint = -1 # TODO: set this based on the value of some verbosity flag
     x = wrk.pulsevals
     x_previous = copy(x)
     n = length(x)
     obj = optimizer
-    bounds = zeros(3, n) # TODO
+    bounds = zeros(3, n) # TODO: allow the problem to specify constraints
     f = 0.0
     message = "n/a"
     # clean up
@@ -87,6 +87,7 @@ function run_optimizer(optimizer::LBFGSB.L_BFGS_B, wrk, fg!, info_hook, check_co
                 # x is the guess for the 0 iteration
                 copyto!(wrk.gradient, obj.g)
                 iter_res = LBFGSB_Result(f, x, x, message_in, message_out)
+                update_result!(wrk, iter_res, obj, 0)
                 wrk.result.J_T = f # TODO: don't mutate result outside of update_result!
                 #update_hook!(...) # TODO
                 info_tuple = info_hook(wrk, iter_res, obj, 0)
@@ -133,6 +134,9 @@ function update_result!(
 )
     # TODO: make this depend only on wrk. Should not be backend-dependent
     res = wrk.result
+    for (k, Ψ) in enumerate(wrk.fw_states)
+        copyto!(res.states[k], Ψ)
+    end
     res.J_T_prev = res.J_T
     res.J_T = iter_res.f
     (i > 0) && (res.iter = i)

--- a/src/backend_optim.jl
+++ b/src/backend_optim.jl
@@ -77,6 +77,9 @@ function update_result!(
 )
     # TODO: make this depend only on wrk. Should not be backend-dependent
     res = wrk.result
+    for (k, Ψ) in enumerate(wrk.fw_states)
+        copyto!(res.states[k], Ψ)
+    end
     res.J_T_prev = res.J_T
     res.J_T = optimization_state.value
     (i > 0) && (res.iter = i)


### PR DESCRIPTION
This uses automatic gradients, making the `gradient` parameter optional.  Gradients are determined directly from the passed `J_T`, either by selecting the appropriate implementation of the analytic gradient, or by constructing a routine via automatic differentiation (via Zygote).

In addition, we can evaluate `∇J_T` not just via a chain rule with respect to overlaps `τ_k` as we have done so far, but also via a chain rule with respect to the forward-propagated states. This allows to set automatic gradients for functionals that cannot be written in terms of overlaps, and/or of objectives that do not define a `target_state`.

This required a major rewrite of the core algorithm: Before, we would backward-propagate the target states, and then forward-propagate the combined initial states and gradients. This is not compatible with automatically evaluating gradients via a chain rule in the states. In that case, we have to backward-propagate not the target states, but states `χ=-∂J/∂⟨ϕ|` that depend on the forward-propagated states. Thus, we have to flip the order of propagations: first forward-propagate that initial states, and then backward-propagate the combined `χ`-states and gradients.

This implements a basic "semi-automatic differentiation" for GRAPE.