### PR TITLE
Make `pulse_options` optional

### DIFF
--- a/examples/perfect_entanglers.jl
+++ b/examples/perfect_entanglers.jl
@@ -281,7 +281,6 @@ J_T_sm(guess_states, objectives)
 
 problem = ControlProblem(
     objectives=objectives,
-    pulse_options=IdDict(),
     tlist=tlist,
     iter_stop=100,
     J_T=J_T_sm,
@@ -420,7 +419,6 @@ J_T_PE(guess_states, objectives)
 
 problem = ControlProblem(
     objectives=objectives,
-    pulse_options=IdDict(),
     tlist=tlist,
     iter_stop=100,
     J_T=J_T_PE,

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -30,7 +30,7 @@ using ConcreteStructs
 
     fg_count::Vector{Int64}
 
-    # Result object
+    # Resultt object
     result
 
     #################################
@@ -77,7 +77,10 @@ function GrapeWrk(problem::QuantumControlBase.ControlProblem; verbose=false)
         )
     )
     kwargs = Dict(problem.kwargs)  # creates a shallow copy; ok to modify
-    pulse_options = problem.pulse_options
+    default_pulse_options = IdDict()  # not used
+    pulse_options = get(kwargs, :pulse_options, default_pulse_options)
+    # TODO: store pulse_options in workspace, allow for things like bounds and
+    # pulse parametrization
     fg_count = zeros(Int64, 2)
     if haskey(kwargs, :continue_from)
         @info "Continuing previous optimization"


### PR DESCRIPTION
They shouldn't be a required property of an optimization problem: Not all optimization methods use them, plus it's possible to have meaningful defaults