### PR TITLE
Implement L-BFGS-B bounds

### DIFF
--- a/src/backend_optim.jl
+++ b/src/backend_optim.jl
@@ -15,6 +15,9 @@ function run_optimizer(
         f_tol=get(wrk.kwargs, :f_tol, 0.0),
         g_tol=get(wrk.kwargs, :g_tol, 1e-8),
     )
+    if any(wrk.lower_bounds .> -Inf) || any(wrk.upper_bounds .< Inf)
+        error("bounds are not implemented for Optim.jl optimization")
+    end
     initial_x = wrk.pulsevals
     method = optimizer
     objective = Optim.promote_objtype(method, initial_x, :finite, true, Optim.only_fg!(fg!))

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -57,6 +57,21 @@ arguments used in the instantiation of `problem`.
 * `lambda_a=1`: A weight for the running cost `J_a`.
 * `grad_J_a`: A function to calculate the gradient of `J_a`. If not given, it
   will be automatically determined.
+* `upper_bound`: An upper bound for the value of any optimized control.
+  Time-dependent upper bounds can be specified via `pulse_options`.
+* `lower_bound`: A lower bound for the value of any optimized control.
+  Time-dependent lower bounds can be specified via `pulse_options`.
+* `pulse_options`: A dictionary that maps every control (as obtained by
+  [`get_controls`](@ref
+  QuantumControlBase.QuantumPropagators.Controls.get_controls) from the
+  `problem.objectives`) to a dict with the following possible keys:
+
+  - `:upper_bounds`: A vector of upper bound values, one for each intervals of
+    the time grid. Values of `Inf` indicate an unconstrained upper bound for
+    that time interval, respectively the global `upper_bound`, if given.
+  - `:lower_bounds`: A vector of lower bound values. Values of `-Inf` indicate
+    an unconstrained lower bound for that time interval,
+
 * `update_hook`: Not implemented
 * `info_hook`: A function that receives the same arguments as `update_hook`, in
   order to write information about the current iteration to the screen or to a


### PR DESCRIPTION
the `optimize_grape` routine can now be called with an `upper_bound` and `lower_bound` parameter. For time-dependent bounds, or different bounds on different pulses, it is also possible to give `pulse_options` with keys `upper_bounds` and `lower_bounds`.

This is only implemented for the L-BFGS-B backend. I couln't really figure out how to add bounds to Optim.jl.

https://github.com/JuliaQuantumControl/QuantumControl.jl/issues/15