### PR TITLE
Catch empty controls in optimization

### DIFF
--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -107,6 +107,9 @@ function GrapeWrk(problem::QuantumControlBase.ControlProblem; verbose=false)
     objectives = [obj for obj in problem.objectives]
     adjoint_objectives = [adjoint(obj) for obj in problem.objectives]
     controls = get_controls(objectives)
+    if length(controls) == 0
+        error("no controls in objectives: cannot optimize")
+    end
     tlist = problem.tlist
     # interleave the pulse values as [ϵ₁(t̃₁), ϵ₂(t̃₁), ..., ϵ₁(t̃₂), ϵ₂(t̃₂), ...]
     # to allow access as reshape(pulsevals, L, :)[l, n] where l is the control

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,11 @@ include(joinpath(@__DIR__, "download_dumps.jl"))
         include("test_pulse_optimization.jl")
     end
 
+    print("\n* Emptry Optimization (test_empty_optimization.jl)")
+    @time @safetestset "Empty Optimization" begin
+        include("test_empty_optimization.jl")
+    end
+
     print("\n* Taylor Gradient (test_taylor_grad.jl):")
     @time @safetestset "Taylor Gradient" begin
         include("test_taylor_grad.jl")

--- a/test/test_empty_optimization.jl
+++ b/test/test_empty_optimization.jl
@@ -1,0 +1,34 @@
+using Test
+using StableRNGs
+using QuantumControl: hamiltonian, optimize, ControlProblem, Objective
+using QuantumControl.Controls: get_controls
+using QuantumControl.Functionals: J_T_re
+using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
+
+@testset "empty optimization" begin
+
+    # Test that trying to run an optimization without any controls produces a
+    # meaningful error message
+
+    rng = StableRNG(2264511904)
+
+    N = 10
+    H = random_matrix(N; rng)
+    objectives = [
+        Objective(;
+            initial_state=random_state_vector(N; rng),
+            generator=H,
+            target_state=random_state_vector(N; rng)
+        )
+    ]
+
+    @test length(get_controls(objectives)) == 0
+
+    tlist = collect(range(0; length=1001, step=1.0))
+
+    problem = ControlProblem(; objectives, tlist, J_T=J_T_re)
+
+    msg = "no controls in objectives: cannot optimize"
+    @test_throws ErrorException(msg) optimize(problem; method=:GRAPE)
+
+end


### PR DESCRIPTION
Trying to run `optimize` when there were no controls in the problem would produce a very non-obvious deep inside the optimizer. Since this is an easy mistake to make, we can catch this situation with a proper error message.

Reported by @leonbello on Slack.

Cf. https://github.com/JuliaQuantumControl/Krotov.jl/pull/32