### PR TITLE
Adapt to renaming of "objective" to "trajectory"

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ links = InterLinks(
         joinpath(@__DIR__, "src", "inventories", "TimerOutputs.toml")
     ),
     "QuantumPropagators" => "https://juliaquantumcontrol.github.io/QuantumPropagators.jl/$DEV_OR_STABLE",
+    "QuantumGradientGenerators" => "https://juliaquantumcontrol.github.io/QuantumGradientGenerators.jl/$DEV_OR_STABLE",
     "QuantumControl" => "https://juliaquantumcontrol.github.io/QuantumControl.jl/$DEV_OR_STABLE",
     "GRAPE" => "https://juliaquantumcontrol.github.io/GRAPE.jl/$DEV_OR_STABLE",
     "Examples" => "https://juliaquantumcontrol.github.io/QuantumControlExamples.jl/$DEV_OR_STABLE",

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -231,3 +231,13 @@
     Pages = {150401},
     Volume = {120},
 }
+
+@article{GoerzNJP2014,
+    Author = {Goerz, Michael H. and Reich, Daniel M. and Koch, Christiane P.},
+    Title = {Optimal control theory for a unitary operation under dissipative evolution},
+    Journal = njp,
+    Year = {2014},
+    Doi = {10.1088/1367-2630/16/5/055012},
+    Pages = {055012},
+    Volume = {16},
+}

--- a/src/result.jl
+++ b/src/result.jl
@@ -25,17 +25,17 @@ mutable struct GrapeResult{STST}
 
     function GrapeResult(problem)
         tlist = problem.tlist
-        controls = get_controls(problem.objectives)
+        controls = get_controls(problem.trajectories)
         iter_start = get(problem.kwargs, :iter_start, 0)
         iter_stop = get(problem.kwargs, :iter_stop, 5000)
         iter = iter_start
         secs = 0
-        tau_vals = zeros(ComplexF64, length(problem.objectives))
+        tau_vals = zeros(ComplexF64, length(problem.trajectories))
         guess_controls = [discretize(control, tlist) for control in controls]
         J_T = 0.0
         J_T_prev = 0.0
         optimized_controls = [copy(guess) for guess in guess_controls]
-        states = [similar(obj.initial_state) for obj in problem.objectives]
+        states = [similar(traj.initial_state) for traj in problem.trajectories]
         start_local_time = now()
         end_local_time = now()
         records = Vector{Tuple}()
@@ -74,7 +74,7 @@ Base.show(io::IO, ::MIME"text/plain", r::GrapeResult) = print(
 GRAPE Optimization Result
 -------------------------
 - Started at $(r.start_local_time)
-- Number of objectives: $(length(r.states))
+- Number of trajectories: $(length(r.states))
 - Number of iterations: $(max(r.iter - r.iter_start, 0))
 - Number of pure func evals: $(r.f_calls)
 - Number of func/grad evals: $(r.fg_calls)

--- a/test/test_empty_optimization.jl
+++ b/test/test_empty_optimization.jl
@@ -1,6 +1,6 @@
 using Test
 using StableRNGs
-using QuantumControl: hamiltonian, optimize, ControlProblem, Objective
+using QuantumControl: hamiltonian, optimize, ControlProblem, Trajectory
 using QuantumControl.Controls: get_controls
 using QuantumControl.Functionals: J_T_re
 using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
@@ -14,21 +14,21 @@ using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
 
     N = 10
     H = random_matrix(N; rng)
-    objectives = [
-        Objective(;
+    trajectories = [
+        Trajectory(;
             initial_state=random_state_vector(N; rng),
             generator=H,
             target_state=random_state_vector(N; rng)
         )
     ]
 
-    @test length(get_controls(objectives)) == 0
+    @test length(get_controls(trajectories)) == 0
 
     tlist = collect(range(0; length=1001, step=1.0))
 
-    problem = ControlProblem(; objectives, tlist, J_T=J_T_re)
+    problem = ControlProblem(trajectories, tlist; J_T=J_T_re)
 
-    msg = "no controls in objectives: cannot optimize"
+    msg = "no controls in trajectories: cannot optimize"
     @test_throws ErrorException(msg) optimize(problem; method=:GRAPE)
 
 end

--- a/test/test_pulse_optimization.jl
+++ b/test/test_pulse_optimization.jl
@@ -10,7 +10,7 @@ using QuantumControl.Functionals: J_T_re
 
     # Test the resolution of
     # https://github.com/JuliaQuantumControl/Krotov.jl/issues/28
-    # 
+    #
     # While this hasn't been a problem for GRAPE, we'd want to make sure that
     # any future changes won't result in the optimization mutating the guess
     # controls
@@ -19,16 +19,16 @@ using QuantumControl.Functionals: J_T_re
 
     problem = dummy_control_problem(; pulses_as_controls=true)
     nt = length(problem.tlist)
-    guess_pulse = QuantumControl.Controls.get_controls(problem.objectives)[1]
+    guess_pulse = QuantumControl.Controls.get_controls(problem.trajectories)[1]
     @test length(guess_pulse) == nt - 1
-    guess_pulse_copy = copy(QuantumControl.Controls.get_controls(problem.objectives)[1])
+    guess_pulse_copy = copy(QuantumControl.Controls.get_controls(problem.trajectories)[1])
 
     # Optimizing this should not modify the original generator in any way
     res = optimize(problem; method=:GRAPE, J_T=J_T_re, iter_stop=2)
     opt_control = res.optimized_controls[1]
     @test length(opt_control) == nt  # optimized_controls are always *on* tlist
     opt_pulse = discretize_on_midpoints(opt_control, problem.tlist)
-    post_pulse = QuantumControl.Controls.get_controls(problem.objectives)[1]
+    post_pulse = QuantumControl.Controls.get_controls(problem.trajectories)[1]
 
     # * The generator should still have the exact same objects as controls
     @test guess_pulse ≡ post_pulse


### PR DESCRIPTION
As a side effect, it is now possible to pass propagation keyword arguments to the trajectory.

See https://github.com/JuliaQuantumControl/QuantumControlBase.jl/pull/72