### PR TITLE
Refactor LBFGSB code into `ext` folder

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,9 @@ Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 
 [extensions]
 GRAPEOptimExt = "Optim"
+# GRAPELBFGSBExt = "LBFGSB"
+# Cannot load GRAPELBFGSBExt as an extension if LBFGSB is a hard
+# dependency. See `include` in `src/GRAPE.jl`.
 
 [compat]
 Dates = "1"

--- a/ext/GRAPELBFGSBExt.jl
+++ b/ext/GRAPELBFGSBExt.jl
@@ -1,5 +1,9 @@
+module GRAPELBFGSBExt
+
 import LBFGSB
-using QuantumControlBase.QuantumPropagators.Controls: discretize
+using GRAPE: GrapeWrk, update_result!
+import GRAPE: run_optimizer, gradient, step_width, search_direction
+
 
 function run_optimizer(optimizer::LBFGSB.L_BFGS_B, wrk, fg!, info_hook, check_convergence!)
 
@@ -126,16 +130,6 @@ function run_optimizer(optimizer::LBFGSB.L_BFGS_B, wrk, fg!, info_hook, check_co
 end
 
 
-function finalize_result!(wrk::GrapeWrk)
-    L = length(wrk.controls)
-    res = wrk.result
-    res.end_local_time = now()
-    ϵ_opt = reshape(wrk.pulsevals, L, :)
-    for l = 1:L
-        res.optimized_controls[l] = discretize(ϵ_opt[l, :], res.tlist)
-    end
-end
-
 function print_lbfgsb_trace(
     wrk,
     optimizer::LBFGSB.L_BFGS_B,
@@ -200,4 +194,6 @@ function search_direction(wrk::GrapeWrk{O}) where {O<:LBFGSB.L_BFGS_B}
     n = length(wrk.pulsevals)
     n0 = wrk.optimizer.isave[13]
     return wrk.optimizer.wa[n0:n0+n-1]
+end
+
 end

--- a/ext/GRAPEOptimExt.jl
+++ b/ext/GRAPEOptimExt.jl
@@ -4,6 +4,7 @@ import Optim
 using GRAPE: GrapeWrk, update_result!
 import GRAPE: run_optimizer, step_width, search_direction
 
+
 function run_optimizer(
     optimizer::Optim.AbstractOptimizer,
     wrk,

--- a/src/GRAPE.jl
+++ b/src/GRAPE.jl
@@ -3,6 +3,6 @@ module GRAPE
 include("workspace.jl")
 include("result.jl")
 include("optimize.jl")
-include("backend_lbfgsb.jl")  # other backends are package extensions
+include(joinpath("..", "ext", "GRAPELBFGSBExt.jl"))
 
 end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -1,4 +1,4 @@
-using QuantumControlBase.QuantumPropagators.Controls: evaluate, evaluate!
+using QuantumControlBase.QuantumPropagators.Controls: evaluate, evaluate!, discretize
 using QuantumControlBase.QuantumPropagators: prop_step!, set_state!, reinit_prop!, propagate
 using QuantumControlBase.QuantumPropagators.Storage: write_to_storage!, get_from_storage!
 using QuantumGradientGenerators: resetgradvec!
@@ -385,6 +385,9 @@ function optimize_grape(problem)
 end
 
 
+function run_optimizer end
+
+
 function update_result!(wrk::GrapeWrk, i::Int64)
     res = wrk.result
     for (k, propagator) in enumerate(wrk.fw_propagators)
@@ -403,6 +406,18 @@ function update_result!(wrk::GrapeWrk, i::Int64)
     res.end_local_time = now()
     res.secs = Dates.toms(res.end_local_time - prev_time) / 1000.0
 end
+
+
+function finalize_result!(wrk::GrapeWrk)
+    L = length(wrk.controls)
+    res = wrk.result
+    res.end_local_time = now()
+    ϵ_opt = reshape(wrk.pulsevals, L, :)
+    for l = 1:L
+        res.optimized_controls[l] = discretize(ϵ_opt[l, :], res.tlist)
+    end
+end
+
 
 
 """Print optimization progress as a table.

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -3,6 +3,7 @@ using QuantumControlBase.QuantumPropagators.Storage: init_storage
 using QuantumControlBase.QuantumPropagators.Controls: get_controls, discretize_on_midpoints
 using QuantumControlBase: Trajectory, get_control_derivs, init_prop_trajectory
 using QuantumGradientGenerators: GradVector, GradGenerator
+import LBFGSB
 
 """Grape Workspace.
 


### PR DESCRIPTION
This is a "pretend" package extension, for symmetry with the Optim extension. It's not possible to have a package extension triggered by a hard dependency, so this uses `include` instead.

However, if we ever wanted to switch the default backend, this makes that easy, as we'd only have to tweak the import in `src/GRAPE.jl` and the list of `[extensions]` in the main `Project.toml`.