### PR TITLE
Allow to continue Krotov optimization in GRAPE and vice versa

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,12 @@ QuantumGradientGenerators = "a563f35e-61db-434d-8c01-8b9e3ccdfd85"
 
 [weakdeps]
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+Krotov = "b05dcdc7-62f6-4360-bf2c-0898bba419de"
+
 
 [extensions]
 GRAPEOptimExt = "Optim"
+GRAPEKrotovExt = "Krotov"
 # GRAPELBFGSBExt = "LBFGSB"
 # Cannot load GRAPELBFGSBExt as an extension if LBFGSB is a hard
 # dependency. See `include` in `src/GRAPE.jl`.
@@ -23,6 +26,7 @@ GRAPEOptimExt = "Optim"
 [compat]
 Dates = "1"
 LBFGSB = "0.4"
+Krotov = "0.6"
 LinearAlgebra = "1"
 Optim = "1"
 Printf = "1"

--- a/ext/GRAPEKrotovExt.jl
+++ b/ext/GRAPEKrotovExt.jl
@@ -1,0 +1,54 @@
+module GRAPEKrotovExt
+
+using GRAPE: GrapeResult
+using Krotov: KrotovResult
+
+function Base.convert(::Type{GrapeResult}, result::KrotovResult{STST}) where {STST}
+    tau_vals = zeros(ComplexF64, length(result.states))
+    # TODO: if Krotov were to properly calculate τ values, we could just copy
+    # them here
+    return GrapeResult{STST}(
+        result.tlist,
+        result.iter_start,
+        result.iter_stop,
+        result.iter,
+        result.secs,
+        tau_vals,
+        result.J_T,
+        result.J_T_prev,
+        result.guess_controls,
+        result.optimized_controls,
+        result.states,
+        result.start_local_time,
+        result.end_local_time,
+        result.records,
+        result.converged,
+        0, # f_calls
+        0, # fg_calls
+        result.message,
+    )
+end
+
+
+function Base.convert(::Type{KrotovResult}, result::GrapeResult{STST}) where {STST}
+    return KrotovResult{STST}(
+        result.tlist,
+        result.iter_start,
+        result.iter_stop,
+        result.iter,
+        result.secs,
+        result.tau_vals,
+        result.J_T,
+        result.J_T_prev,
+        result.guess_controls,
+        result.optimized_controls,
+        result.states,
+        result.start_local_time,
+        result.end_local_time,
+        result.records,
+        result.converged,
+        result.message,
+    )
+end
+
+end

--- a/src/result.jl
+++ b/src/result.jl
@@ -23,47 +23,48 @@ mutable struct GrapeResult{STST}
     fg_calls::Int64
     message::String
 
-    function GrapeResult(problem)
-        tlist = problem.tlist
-        controls = get_controls(problem.trajectories)
-        iter_start = get(problem.kwargs, :iter_start, 0)
-        iter_stop = get(problem.kwargs, :iter_stop, 5000)
-        iter = iter_start
-        secs = 0
-        tau_vals = zeros(ComplexF64, length(problem.trajectories))
-        guess_controls = [discretize(control, tlist) for control in controls]
-        J_T = 0.0
-        J_T_prev = 0.0
-        optimized_controls = [copy(guess) for guess in guess_controls]
-        states = [similar(traj.initial_state) for traj in problem.trajectories]
-        start_local_time = now()
-        end_local_time = now()
-        records = Vector{Tuple}()
-        converged = false
-        message = "in progress"
-        f_calls = 0
-        fg_calls = 0
-        new{eltype(states)}(
-            tlist,
-            iter_start,
-            iter_stop,
-            iter,
-            secs,
-            tau_vals,
-            J_T,
-            J_T_prev,
-            guess_controls,
-            optimized_controls,
-            states,
-            start_local_time,
-            end_local_time,
-            records,
-            converged,
-            f_calls,
-            fg_calls,
-            message
-        )
-    end
+end
+
+function GrapeResult(problem)
+    tlist = problem.tlist
+    controls = get_controls(problem.trajectories)
+    iter_start = get(problem.kwargs, :iter_start, 0)
+    iter_stop = get(problem.kwargs, :iter_stop, 5000)
+    iter = iter_start
+    secs = 0
+    tau_vals = zeros(ComplexF64, length(problem.trajectories))
+    guess_controls = [discretize(control, tlist) for control in controls]
+    J_T = 0.0
+    J_T_prev = 0.0
+    optimized_controls = [copy(guess) for guess in guess_controls]
+    states = [similar(traj.initial_state) for traj in problem.trajectories]
+    start_local_time = now()
+    end_local_time = now()
+    records = Vector{Tuple}()
+    converged = false
+    message = "in progress"
+    f_calls = 0
+    fg_calls = 0
+    GrapeResult{eltype(states)}(
+        tlist,
+        iter_start,
+        iter_stop,
+        iter,
+        secs,
+        tau_vals,
+        J_T,
+        J_T_prev,
+        guess_controls,
+        optimized_controls,
+        states,
+        start_local_time,
+        end_local_time,
+        records,
+        converged,
+        f_calls,
+        fg_calls,
+        message
+    )
 end
 
 


### PR DESCRIPTION
Implementing `Base.convert` between the different Result objects allows `continue_from` to work.