### PR TITLE
Make `chi` functions not-in-place

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,7 +38,8 @@ links = InterLinks(
 )
 
 fallbacks = ExternalFallbacks(
-    "QuantumControlBase.ControlProblem" => "@extref QuantumControlBase.ControlProblem",
+    "ControlProblem" => "@extref QuantumControl :jl:type:`QuantumControlBase.ControlProblem`",
+    "QuantumControlBase.ControlProblem" => "@extref QuantumControl :jl:type:`QuantumControlBase.ControlProblem`",
     "make_chi" => "@extref QuantumControlBase.make_chi",
     "QuantumControlBase.QuantumPropagators.Controls.get_controls" => "@extref QuantumPropagators.Controls.get_controls",
     "Trajectory" => "@extref QuantumControlBase.Trajectory",

--- a/ext/GRAPELBFGSBExt.jl
+++ b/ext/GRAPELBFGSBExt.jl
@@ -16,7 +16,6 @@ function run_optimizer(optimizer::LBFGSB.L_BFGS_B, wrk, fg!, callback, check_con
     n = length(x)
     obj = optimizer
     f = 0.0
-    message = "n/a"
     # clean up
     fill!(obj.task, Cuchar(' '))
     fill!(obj.csave, Cuchar(' '))

--- a/src/result.jl
+++ b/src/result.jl
@@ -14,7 +14,7 @@ The attributes of a `GrapeResult` object include
 * `tlist`: The time grid on which the control are discetized.
 * `guess_controls`: A vector of the original control fields (each field
   discretized to the points of `tlist`)
-* optimized_controls: A vector of the optimized control fileds in the current
+* optimized_controls: A vector of the optimized control fields in the current
   iterations
 * records: A vector of tuples with values returned by a `callback` routine
   passed to [`optimize`](@ref)


### PR DESCRIPTION
The `chi!` functions previously used by GRAPE and Krotov are now simply `chi` do not act in-place. This is more general and easier to implement for the user, as it allows to use immutable structs for states

Note that in extreme performance-critical situations, one could still construct the χ-states in-place via a closure or functor.

Both chi and J_T can now have an optional keyword argument `tau` (instead of the previous improperly implemented and unicode `τ`). Whether or not `tau` should be passed to these functions is automatically detected.