### PR TITLE
Allow to configure which info is printed per iteration

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -42,7 +42,8 @@ fallbacks = ExternalFallbacks(
     "QuantumControl.QuantumPropagators.Controls.get_controls" => "@extref QuantumPropagators.Controls.get_controls",
     "Trajectory" => "@extref QuantumControl.Trajectory",
     "propagate" => "@extref QuantumPropagators.propagate",
-    "init_prop_trajectory" => "@extref QuantumControl.init_prop_trajectory"
+    "init_prop_trajectory" => "@extref QuantumControl.init_prop_trajectory",
+    "Functional" => "@extref QuantumControl :std:label:`Functional`",
 )
 
 println("Starting makedocs")

--- a/ext/GRAPELBFGSBExt.jl
+++ b/ext/GRAPELBFGSBExt.jl
@@ -2,7 +2,7 @@ module GRAPELBFGSBExt
 
 import LBFGSB
 using GRAPE: GrapeWrk, update_result!
-import GRAPE: run_optimizer, gradient, step_width, search_direction
+import GRAPE: run_optimizer, gradient, step_width, search_direction, norm_search
 
 
 function run_optimizer(optimizer::LBFGSB.L_BFGS_B, wrk, fg!, callback, check_convergence!)
@@ -195,6 +195,17 @@ function search_direction(wrk::GrapeWrk{O}) where {O<:LBFGSB.L_BFGS_B}
     n = length(wrk.pulsevals)
     n0 = wrk.optimizer.isave[13]
     return wrk.optimizer.wa[n0:n0+n-1]
+end
+
+
+function norm_search(wrk::GrapeWrk{O}) where {O<:LBFGSB.L_BFGS_B}
+    n = length(wrk.pulsevals)
+    n0 = wrk.optimizer.isave[13]
+    r = 0.0
+    for i = n0:n0+n-1
+        r += wrk.optimizer.wa[i]^2
+    end
+    return sqrt(r)
 end
 
 end

--- a/ext/GRAPEOptimExt.jl
+++ b/ext/GRAPEOptimExt.jl
@@ -52,7 +52,8 @@ function run_optimizer(
         if hasproperty(objective, :DF)
             # DF is the *current* gradient, i.e., the gradient of the updated
             # pulsevals, which (after the call to `callback`) is the gradient
-            # for the the guess of the next iteration.
+            # for the the guess of the next iteration. It's important that
+            # we're setting this after the GRAPE.jl `callback`
             wrk.gradient .= objective.DF
         elseif (optimization_state.iteration == 1)
             @error "Cannot determine guess gradient"

--- a/src/result.jl
+++ b/src/result.jl
@@ -12,6 +12,9 @@ The attributes of a `GrapeResult` object include
 * `iter`:  The number of the current iteration
 * `J_T`: The value of the final-time functional in the current iteration
 * `J_T_prev`: The value of the final-time functional in the previous iteration
+* `J_a`: The value of the running cost ``J_a`` in the current iteration
+  (excluding ``λ_a``)
+* `J_a_prev`: The value of ``J_a`` in the previous iteration
 * `tlist`: The time grid on which the control are discetized.
 * `guess_controls`: A vector of the original control fields (each field
   discretized to the points of `tlist`)
@@ -36,6 +39,8 @@ mutable struct GrapeResult{STST} <: AbstractOptimizationResult
     tau_vals::Vector{ComplexF64}
     J_T::Float64  # the current value of the final-time functional J_T
     J_T_prev::Float64  # previous value of J_T
+    J_a::Float64  # the current value of the functional J_a (excluding λ_a)
+    J_a_prev::Float64  # previous value of J_a
     guess_controls::Vector{Vector{Float64}}
     optimized_controls::Vector{Vector{Float64}}
     states::Vector{STST}
@@ -60,6 +65,8 @@ function GrapeResult(problem)
     guess_controls = [discretize(control, tlist) for control in controls]
     J_T = 0.0
     J_T_prev = 0.0
+    J_a = 0.0
+    J_a_prev = 0.0
     optimized_controls = [copy(guess) for guess in guess_controls]
     states = [similar(traj.initial_state) for traj in problem.trajectories]
     start_local_time = now()
@@ -78,6 +85,8 @@ function GrapeResult(problem)
         tau_vals,
         J_T,
         J_T_prev,
+        J_a,
+        J_a_prev,
         guess_controls,
         optimized_controls,
         states,
@@ -111,6 +120,7 @@ GRAPE Optimization Result
 
 
 function Base.convert(::Type{GrapeResult}, result::AbstractOptimizationResult)
-    defaults = Dict{Symbol,Any}(:f_calls => 0, :fg_calls => 0,)
+    defaults =
+        Dict{Symbol,Any}(:f_calls => 0, :fg_calls => 0, :J_a => 0.0, :J_a_prev => 0.0)
     return convert(GrapeResult, result, defaults)
 end

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -23,8 +23,11 @@ attributes:
 * `pulsevals`: The combined vector of updated pulse values in the current
   iteration.
 * `gradient`: The total gradient for the guess in the current iteration
-* `grad_J_T`: The current gradient for the final-time part of the functional.
-* `grad_J_a`: The current gradient for the running cost part of the functional.
+* `grad_J_T`: The *current*  gradient for the final-time part of the
+  functional. This is from the last evaluation of the gradient, which may be
+  for the optimized pulse (depending on the internal of the optimizer)
+* `grad_J_a`: The *current*  gradient for the running cost part of the
+  functional.
 * `J_parts`: The two-component vector ``[J_T, J_a]``
 * `result`: The current result object
 * `upper_bounds`: Upper bound for every `pulsevals`; `+Inf` indicates no bound.
@@ -51,6 +54,7 @@ information in the workspace
 
 * [`step_width`](@ref)
 * [`search_direction`](@ref)
+* [`norm_search`](@ref)
 * [`gradient`](@ref)
 * [`pulse_update`](@ref)
 """
@@ -359,6 +363,24 @@ iteration. This should be proportional to [`pulse_update`](@ref) with the
 proportionality factor [`step_width`](@ref).
 """
 search_direction(wrk) = -gradient(wrk; which=:initial)  # assumed fallback
+
+
+"""The norm of the search direction vector in the current iteration.
+
+```julia
+norm_search(wrk)
+```
+
+returns `norm(search_direction(wrk))`.
+"""
+function norm_search(wrk)
+    s = search_direction(wrk)
+    r = 0.0
+    for sᵢ in s
+        r += sᵢ^2
+    end
+    return sqrt(r)
+end
 
 
 """The gradient in the current iteration.


### PR DESCRIPTION
Adds the `print_iter_info` option, which gives access to a greatly increased number of fields. Modifies the default fields to make more sense in the presence of running costs.