### PR TITLE
Refactor to use  `evaluate_functional` and `evaluate_gradient!`, normalize χ

### DIFF
--- a/src/result.jl
+++ b/src/result.jl
@@ -18,17 +18,18 @@ The attributes of a `GrapeResult` object include
 * `tlist`: The time grid on which the control are discetized.
 * `guess_controls`: A vector of the original control fields (each field
   discretized to the points of `tlist`)
-* optimized_controls: A vector of the optimized control fields in the current
+* `optimized_controls`: A vector of the optimized control fields in the current
   iterations
-* records: A vector of tuples with values returned by a `callback` routine
+* `records`: A vector of tuples with values returned by a `callback` routine
   passed to [`optimize`](@ref)
-* converged: A boolean flag on whether the optimization is converged. This
+* `converged`: A boolean flag on whether the optimization is converged. This
   may be set to `true` by a `check_convergence` function.
-* message: A message string to explain the reason for convergence. This may be
+* `message`: A message string to explain the reason for convergence. This may be
   set by a `check_convergence` function.
 
 All of the above attributes may be referenced in a `check_convergence` function
-passed to [`optimize(problem; method=GRAPE)`](@ref QuantumControl.optimize(::ControlProblem, ::Val{:GRAPE}))
+passed to
+[`optimize(problem; method=GRAPE)`](@ref optimize(::Any, ::Val{:GRAPE}))
 """
 mutable struct GrapeResult{STST} <: AbstractOptimizationResult
     tlist::Vector{Float64}


### PR DESCRIPTION
Normalizing χ prior to the backward propagation should increase numerical stability and allow to detect vanishing gradients.

To make all of this easier to debug and test, this also refactors the `optimize_grape` function into new  `evaluate_functional` and `evaluate_gradient!` that properly document the side effects on the GRAPE workspace from evaluating the functional or the gradient