### PR TITLE
Use high-precision flags for LBFGSB

### DIFF
--- a/ext/GRAPELBFGSBExt.jl
+++ b/ext/GRAPELBFGSBExt.jl
@@ -200,7 +200,7 @@ end
 function search_direction(wrk::GrapeWrk{O}) where {O<:LBFGSB.L_BFGS_B}
     n = length(wrk.pulsevals)
     n0 = wrk.optimizer.isave[13]
-    return wrk.optimizer.wa[n0:n0+n-1]
+    return wrk.optimizer.wa[n0:(n0+n-1)]
 end
 
 
@@ -208,7 +208,7 @@ function norm_search(wrk::GrapeWrk{O}) where {O<:LBFGSB.L_BFGS_B}
     n = length(wrk.pulsevals)
     n0 = wrk.optimizer.isave[13]
     r = 0.0
-    for i = n0:n0+n-1
+    for i = n0:(n0+n-1)
         r += wrk.optimizer.wa[i]^2
     end
     return sqrt(r)

--- a/ext/GRAPELBFGSBExt.jl
+++ b/ext/GRAPELBFGSBExt.jl
@@ -8,8 +8,14 @@ import GRAPE: run_optimizer, gradient, step_width, search_direction, norm_search
 function run_optimizer(optimizer::LBFGSB.L_BFGS_B, wrk, fg!, callback, check_convergence!)
 
     m = get(wrk.kwargs, :lbfgsb_m, 10)
-    factr = get(wrk.kwargs, :lbfgsb_factr, 1e7)
-    pgtol = get(wrk.kwargs, :lbfgsb_pgtol, 1e-5)
+    factr = get(wrk.kwargs, :lbfgsb_factr, 1e1)
+    # LBFGSB stops when the relative reduction in the functional f is
+    #     (f^k - f^{k+1})/max{|f^k|,|f^{k+1}|,1} <= factr*epsmch
+    pgtol = get(wrk.kwargs, :lbfgsb_pgtol, 1e-15)
+    # LBFGSB will stop when the i'th component of the projected gradient g_i is
+    #     max{|proj g_i | i = 1, ..., n} <= pgtol
+    # We set both `factr` and `pgtol` to "extreme" high accuracy. We really
+    # want GRAPE to control the convergence check, not LBFGSB.
     iprint = get(wrk.kwargs, :lbfgsb_iprint, -1)
     trace_debugging = (iprint == 100)
     x = wrk.pulsevals

--- a/ext/GRAPEOptimExt.jl
+++ b/ext/GRAPEOptimExt.jl
@@ -69,7 +69,7 @@ function run_optimizer(
 
     options = Optim.Options(
         callback=optim_callback,
-        iterations=wrk.result.iter_stop - wrk.result.iter_start, # TODO
+        iterations=(wrk.result.iter_stop - wrk.result.iter_start), # TODO
         x_tol=get(wrk.kwargs, :x_tol, 0.0),
         f_tol=get(wrk.kwargs, :f_tol, 0.0),
         g_tol=get(wrk.kwargs, :g_tol, 1e-8),

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -329,7 +329,7 @@ function finalize_result!(wrk::GrapeWrk)
     res.end_local_time = now()
     N_T = length(res.tlist) - 1
     for l = 1:L
-        ϵ_opt = wrk.pulsevals[(l-1)*N_T+1:l*N_T]
+        ϵ_opt = wrk.pulsevals[((l-1)*N_T+1):(l*N_T)]
         res.optimized_controls[l] = discretize(ϵ_opt, res.tlist)
     end
 end
@@ -889,7 +889,7 @@ function evaluate_gradient!(G, pulsevals, problem, wrk)
                     if isnothing(μₖₗ)
                         wrk.tau_grads[k][n, l] = 0.0
                     else
-                        local ϵₙ⁽ⁱ⁾ = @view pulsevals[(n-1)*L+1:n*L]
+                        local ϵₙ⁽ⁱ⁾ = @view pulsevals[((n-1)*L+1):(n*L)]
                         local vals_dict = IdDict(
                             control => val for (control, val) ∈ zip(wrk.controls, ϵₙ⁽ⁱ⁾)
                         )

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -762,7 +762,7 @@ of the optimization functional with respect to the pulse values into the
 existing array `G`.
 
 The evaluation of the functional uses uses `wrk.fw_propagators`. The evaluation
-of the gradient happens either via a backward propagation of an extented
+of the gradient happens either via a backward propagation of an extended
 ["gradient vector"](@extref `QuantumGradientGenerators.GradVector`)
 using `wrk.bw_grad_propagators` if `problem` was initialized with
 `gradient_method=:gradgen`. Alternatively, if `problem` was initialized with

--- a/src/workspace.jl
+++ b/src/workspace.jl
@@ -175,7 +175,7 @@ function GrapeWrk(problem::QuantumControl.ControlProblem; verbose=false)
     parameters = IdDict(
         # The view-aliasing below ensures that we can mutate `pulsevals` and
         # the updated values are immediately accessible in the propagation
-        control => @view pulsevals[(l-1)*N_T+1:l*N_T] for
+        control => @view pulsevals[((l-1)*N_T+1):(l*N_T)] for
         (l, control) in enumerate(controls)
     )
     gradient = zeros(length(pulsevals))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,11 @@ unicodeplots()
         include("test_taylor_grad.jl")
     end
 
+    println("\n* LBFGSB Saddle point (test_lbfgsb_saddle_point.jl):")
+    @time @safetestset "LBFGSB Saddle point" begin
+        include("test_lbfgsb_saddle_point.jl")
+    end
+
     println("\n* Iterations (test_iterations.jl)")
     @time @safetestset "Iterations" begin
         include("test_iterations.jl")

--- a/test/test_lbfgsb_saddle_point.jl
+++ b/test/test_lbfgsb_saddle_point.jl
@@ -1,0 +1,120 @@
+using Test
+
+using QuantumControl: hamiltonian, Trajectory, ControlProblem, optimize
+using QuantumControl.Shapes: box
+using QuantumControl.Amplitudes: ShapedAmplitude
+using QuantumPropagators: Cheby
+using QuantumControl.Functionals: J_T_sm
+using LinearAlgebra: kron
+using GRAPE
+
+const ⊗ = kron
+
+
+function two_qubit_hamiltonian(; ϵ1, ϵ2, ϵ3, ϵ4, ϵ5, ϵ6,)
+    𝟙 = ComplexF64[
+        1  0
+        0  1
+    ]
+    σz = ComplexF64[
+        1  0
+        0 -1
+    ]
+    σx = ComplexF64[
+        0  1
+        1  0
+    ]
+    σy = ComplexF64[
+        0  -1im
+        1im  0
+    ]
+    Ĥ1 = σx ⊗ 𝟙
+    Ĥ2 = σy ⊗ 𝟙
+    Ĥ3 = σz ⊗ 𝟙
+    Ĥ4 = 𝟙 ⊗ σx
+    Ĥ5 = 𝟙 ⊗ σy
+    Ĥ6 = 𝟙 ⊗ σz
+    Ĥ0 = π / 2 * σy ⊗ σy
+    return hamiltonian(
+        Ĥ0,
+        (Ĥ1, ϵ1),
+        (Ĥ2, ϵ2),
+        (Ĥ3, ϵ3),
+        (Ĥ4, ϵ4),
+        (Ĥ5, ϵ5),
+        (Ĥ6, ϵ6)
+    )
+end;
+
+
+function guess_amplitudes(; T=1.0, E₀=0.1, dt=0.001)
+
+    tlist = collect(range(0, T, step=dt))
+    shape(t) = box(t, 0.0, T)
+    ϵ1 = ShapedAmplitude(t -> E₀, tlist; shape)
+    ϵ2 = ShapedAmplitude(t -> E₀, tlist; shape)
+    ϵ3 = ShapedAmplitude(t -> E₀, tlist; shape)
+    ϵ4 = ShapedAmplitude(t -> E₀, tlist; shape)
+    ϵ5 = ShapedAmplitude(t -> E₀, tlist; shape)
+    ϵ6 = ShapedAmplitude(t -> E₀, tlist; shape)
+
+    return tlist, ϵ1, ϵ2, ϵ3, ϵ4, ϵ5, ϵ6
+
+end
+
+function ket(i::Int64; N=2)
+    Ψ = zeros(ComplexF64, N)
+    Ψ[i+1] = 1
+    return Ψ
+end
+
+function ket(indices::Int64...; N=2)
+    Ψ = ket(indices[1]; N)
+    for i in indices[2:end]
+        Ψ = Ψ ⊗ ket(i; N)
+    end
+    return Ψ
+end
+
+function ket(label::AbstractString; N=2)
+    indices = [parse(Int64, digit) for digit in label]
+    return ket(indices...; N)
+end;
+
+
+@testset "CNOT with single-qubit drives and static interaction" begin
+
+    tlist, Ω1, Ω2, Ω3, Ω4, Ω5, Ω6 = guess_amplitudes()
+    CNOT = ComplexF64[
+        1  0  0  0
+        0  1  0  0
+        0  0  0  1
+        0  0  1  0
+    ]
+    basis = [ket("00"), ket("01"), ket("10"), ket("11")]
+    basis_tgt = transpose(CNOT) * basis
+    H = two_qubit_hamiltonian(ϵ1=Ω1, ϵ2=Ω2, ϵ3=Ω3, ϵ4=Ω4, ϵ5=Ω5, ϵ6=Ω6)
+    trajectories = [
+        Trajectory(initial_state=Ψ, target_state=Ψtgt, generator=H) for
+        (Ψ, Ψtgt) ∈ zip(basis, basis_tgt)
+    ]
+    problem = ControlProblem(
+        trajectories,
+        tlist;
+        iter_stop=50,
+        prop_method=Cheby,
+        use_threads=true,
+        J_T=J_T_sm,
+    )
+
+    # with "medium precision" (old defaults), this gets stuck at a saddle point
+    opt_result = optimize(problem; method=GRAPE, lbfgsb_pgtol=1e-5, lbfgsb_factr=1e7)
+    @test !opt_result.converged
+    @test contains(opt_result.message, "NORM_OF_PROJECTED_GRADIENT_<=_PGTOL")
+    @test abs(opt_result.J_T - 0.75) < 1e-3
+
+    opt_result = optimize(problem; method=GRAPE)
+    @test opt_result.converged
+    @test opt_result.J_T < 1e-2
+
+end


### PR DESCRIPTION
This should prevent getting stuck in saddle points, or generally, aborting and optimization because L-BFGS-B thinks it has converged. We can the convergence check to happen inside GRAPE, not inside L-BFGS-B

Closes #85 